### PR TITLE
update types to match what is found in PEP/Consumer

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -89,8 +89,7 @@ export enum State {
 }
 
 export type Image = {
-	id: number;
-	url: string;
+	src: string;
 };
 
 export type EligibleProjectType = {
@@ -104,7 +103,7 @@ export type FinancialAuthority = {
 	description: string | null;
 	state: any;
 	city: string | null;
-	image_id: number | null;
+	Image: { src: string };
 	created_at: Date;
 	updated_at: Date;
 };

--- a/src/types.ts
+++ b/src/types.ts
@@ -98,10 +98,10 @@ export type EligibleProjectType = {
 
 export type FinancialAuthority = {
 	id: number;
-	authority_type: any;
+	authority_type: AuthorityType;
 	name: string;
 	description?: string | null;
-	state: any;
+	state: State;
 	city: string | null;
 	Image: { src: string };
 	created_at?: Date;
@@ -112,14 +112,14 @@ export type LoanProgram = {
 	id: number;
 	name: string;
 	description: string;
-	description_langs?: any;
-	website_url: string | null;
+	description_langs?: Record<string, string>;
+	website_url: string;
 	financial_authority_id?: number;
 	financial_authority: FinancialAuthority;
 	eligible_project_types: { type: ProjectType }[];
-	state: any;
+	state: State;
 	is_national: boolean;
-	metadata: any;
+	metadata: Record<string, any>;
 	created_at: Date;
 	updated_at: Date;
 };

--- a/src/types.ts
+++ b/src/types.ts
@@ -100,12 +100,12 @@ export type FinancialAuthority = {
 	id: number;
 	authority_type: any;
 	name: string;
-	description: string | null;
+	description?: string | null;
 	state: any;
 	city: string | null;
 	Image: { src: string };
-	created_at: Date;
-	updated_at: Date;
+	created_at?: Date;
+	updated_at?: Date;
 };
 
 export type LoanProgram = {
@@ -114,9 +114,9 @@ export type LoanProgram = {
 	description: string;
 	description_langs?: any;
 	website_url: string | null;
-	financial_authority_id: number;
+	financial_authority_id?: number;
 	financial_authority: FinancialAuthority;
-	eligible_project_types: any;
+	eligible_project_types: { type: ProjectType }[];
 	state: any;
 	is_national: boolean;
 	metadata: any;


### PR DESCRIPTION
I noticed some types were incorrect for what exists in PEP/Consumer [data.json](https://github.com/rewiringamerica/consumer/blob/main/api-homes-rewiringamerica/domains/financial-programs/data.json#L27-L28) here https://github.com/rewiringamerica/consumer/pull/1729