### PR TITLE
Add license to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "url": "https://github.com/rewiringamerica/capital-common.git"
   },
   "author": "Rewiring America",
-  "license": "UNLICENSED",
+  "license": "Apache-2.0",
   "devDependencies": {
     "@eslint/js": "^9.16.0",
     "@typescript-eslint/eslint-plugin": "^8.20.0",


### PR DESCRIPTION
I added the Apache-2.0 license to the repo in #42, but I believe that we need to specify the license in package.json as well in order display it correctly on the npm page.

## Changes

- Update package.json with the license

## Test Plan

- Check the `License` on https://www.npmjs.com/package/@rewiringamerica/capital-common after publishing a new version.

## Developer Checklist

-   [ ] _I have tested the changes in this PR_
-   [ ] _I have added unit tests for this PR_
-   [ ] _I have updated the documentation, if applicable_

## Next steps

N/A
