### PR TITLE
Add a comment to keep the ProjectType enum in sync with HERO

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -12,6 +12,8 @@ export enum AuthorityType {
   OTHER = "other",
 }
 
+// NOTE: This list of enum values should be kept in sync with the values in the 'incentive_admin' repo.
+// File location: incentive_admin/prisma/schema/capital.prisma
 export enum ProjectType {
   WEATHERIZATION = "WEATHERIZATION",
   HEATING_COOLING = "HEATING_COOLING",


### PR DESCRIPTION
Just adding a note for developers to keep the `ProjectType` enum values in sync with HERO.
[Asana ticket](https://app.asana.com/0/1209314265771880/1209162126439107/f)