### PR TITLE
Add height and width to the image type

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -102,6 +102,8 @@ export enum State {
 
 export type Image = {
   src: string;
+  height: number;
+  width: number;
 };
 
 export type EligibleProjectType = {


### PR DESCRIPTION
## Changes
- Add `height` and `width` to the `Image` type, to be consistent with the type in HERO.